### PR TITLE
applications: asset_tracker: fix LOG argument type

### DIFF
--- a/applications/asset_tracker/src/main.c
+++ b/applications/asset_tracker/src/main.c
@@ -731,7 +731,7 @@ static void cloud_connect_work_fn(struct k_work *work)
 {
 	int ret;
 
-	LOG_INF("Connecting to cloud, attempt %d of %d",
+	LOG_INF("Connecting to cloud, attempt %ld of %d",
 	       atomic_get(&cloud_connect_attempts),
 		   CONFIG_CLOUD_CONNECT_COUNT_MAX);
 


### PR DESCRIPTION
Now use correct LOG argument types

Signed-off-by: Jon Helge Nistad <jon.helge.nistad@nordicsemi.no>