### PR TITLE
subsystem: openthread: adjust mbedtls configuration to nRF Security

### DIFF
--- a/subsys/net/openthread/Kconfig.defconfig
+++ b/subsys/net/openthread/Kconfig.defconfig
@@ -54,6 +54,14 @@ choice OPENTHREAD_SECURITY
 	default OPENTHREAD_NRF_SECURITY_CHOICE
 endchoice
 
+config MBEDTLS_SSL_PROTO_DTLS
+	bool
+	default y
+
+config MBEDTLS_ENTROPY_C
+	bool
+	default y
+
 config MBEDTLS_CIPHER_MODE_CBC
 	bool
 	default n


### PR DESCRIPTION
After updating nRF Security MBEDTLS_SSL_PROTO_DTLS and
MBEDTLS_ENTROPY_C options need to be enabled explicitly.

Signed-off-by: Lukasz Maciejonczyk <lukasz.maciejonczyk@nordicsemi.no>