### PR TITLE
tfm: Add internal trusted storage and increase TF-M minimal size

### DIFF
--- a/modules/trusted-firmware-m/Kconfig
+++ b/modules/trusted-firmware-m/Kconfig
@@ -77,7 +77,7 @@ config PM_PARTITION_SIZE_BL2
 config PM_PARTITION_SIZE_TFM
 	hex
 	prompt  "Memory reserved for TFM" if !TFM_MINIMAL
-	default 0x8000 if TFM_MINIMAL
+	default 0x10000 if TFM_MINIMAL
 	default 0x40000
 	help
 	  Memory set aside for the TFM partition. This size is fixed if

--- a/modules/trusted-firmware-m/Kconfig.tfm_minimal.defconfig
+++ b/modules/trusted-firmware-m/Kconfig.tfm_minimal.defconfig
@@ -18,3 +18,7 @@ config TFM_PARTITION_CRYPTO
 config TFM_PARTITION_PLATFORM
 	bool
 	default y
+
+config TFM_PARTITION_INTERNAL_TRUSTED_STORAGE
+	bool
+	default y


### PR DESCRIPTION
Add internal trusted storage partition which is required by the
crypto partition to the minimal TF-M configuration.
The size of the minimal configuration had to be increased.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>